### PR TITLE
Update trackstamps.gemspec

### DIFF
--- a/trackstamps.gemspec
+++ b/trackstamps.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails", '~> 5'
-  s.add_dependency "devise", '~> 4.2.0'
+  s.add_dependency "devise", '> 4.2.0'
 
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
Updated to allow newer versions of devise to be able to use in Rails 5.1. Maybe consider taking out the dependency on devise. The only real requirement is there is a current_user method. 